### PR TITLE
Corrected access issue to Vagrant postgres

### DIFF
--- a/Vagrantfile_postgres
+++ b/Vagrantfile_postgres
@@ -79,6 +79,8 @@ Vagrant.configure("2") do |config|
     yum clean all
     systemctl enable postgresql.service
     sudo -u postgres initdb -D /var/lib/pgsql/data
+    sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /var/lib/pgsql/data/postgresql.conf
+    echo "host    all             all             0.0.0.0/0            trust" >> /var/lib/pgsql/data/pg_hba.conf
     systemctl start postgresql.service
   SHELL
 end


### PR DESCRIPTION
Corrected the issue that didn't allow to access from the host
to the Vagrant guest. Postgres DB is now accessible from the
host using port forward. User postgres has admin access